### PR TITLE
feat(api): add FastAPI endpoints for indexing and retrieval

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,31 @@
+# app/api.py
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from app.rag import index_document, retrieve
+
+app = FastAPI(title="RAG Chatbot API")
+
+class IndexRequest(BaseModel):
+    text: str
+    doc_id: int
+
+class RetrieveRequest(BaseModel):
+    query: str
+    k: int = 3
+
+@app.post("/index", summary="Index a new document")
+def api_index(req: IndexRequest):
+    try:
+        index_document(req.text, req.doc_id)
+        return {"status": "ok", "doc_id": req.doc_id}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/retrieve", summary="Retrieve top-k document IDs")
+def api_retrieve(req: RetrieveRequest):
+    try:
+        ids = retrieve(req.query, k=req.k)
+        return {"status": "ok", "doc_ids": ids.tolist()}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
This PR adds a simple FastAPI application exposing two endpoints:

1. **POST /index**  
   - Accepts JSON `{ "text": string, "doc_id": int }`  
   - Calls `index_document(text, doc_id)` to embed and store the document in FAISS.

2. **POST /retrieve**  
   - Accepts JSON `{ "query": string, "k": int }`  
   - Calls `retrieve(query, k)` to return the top-k document IDs as JSON.

It also:
- Defines Pydantic models (`IndexRequest`, `RetrieveRequest`) for payload validation.
- Includes error handling via `HTTPException`.

**How to test locally:**  
```bash
uvicorn app.api:app --reload
# then:
curl -X POST localhost:8000/index \
     -H "Content-Type: application/json" \
     -d '{"text":"Hello world","doc_id":42}'
curl -X POST localhost:8000/retrieve \
     -H "Content-Type: application/json" \
     -d '{"query":"Hello","k":1}'
